### PR TITLE
Use in-memory DB to avoid creating files

### DIFF
--- a/GoodLuck/GoodLuck.csproj
+++ b/GoodLuck/GoodLuck.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/GoodLuck/Program.cs
+++ b/GoodLuck/Program.cs
@@ -11,10 +11,8 @@ namespace GoodLuck
 
             // Add services to the container.
             builder.Services.AddControllersWithViews();
-            var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
-                ?? "Server=localhost;Database=GoodLuckDb;User Id=sa;Password=sa123;TrustServerCertificate=True;";
             builder.Services.AddDbContext<GoodLuck.Models.AppDbContext>(options =>
-                options.UseSqlServer(connectionString));
+                options.UseInMemoryDatabase("GoodLuckDb"));
 
             var app = builder.Build();
 

--- a/GoodLuck/appsettings.json
+++ b/GoodLuck/appsettings.json
@@ -5,8 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Database=GoodLuckDb;User Id=sa;Password=sa123;TrustServerCertificate=True;"
-  }
+  "AllowedHosts": "*"
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GoodLuck
 
 This project is an ASP.NET Core web application for managing special messages.
-It now includes simple pages to keep letters and anniversaries in a SQLite
-database.
+It now includes simple pages to keep letters and anniversaries in an
+in‑memory database so no files are created on disk.
 
 ## Getting Started
 
@@ -10,4 +10,5 @@ database.
 2. Restore packages with `dotnet restore`.
 3. Run the project with `dotnet run`.
 
-The database file `app.db` will be created automatically on first run.
+Because the database is in memory, no database file will be generated when
+running the application.


### PR DESCRIPTION
## Summary
- keep data in memory so no files are generated
- update documentation

## Testing
- `dotnet restore GoodLuck/GoodLuck.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685422c22e7c8327b66591d7cc4379e3