### PR TITLE
Enable SQL Server connection

### DIFF
--- a/GoodLuck/Program.cs
+++ b/GoodLuck/Program.cs
@@ -12,8 +12,10 @@ namespace GoodLuck
 
             // Add services to the container.
             builder.Services.AddControllersWithViews();
+
+            var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
             builder.Services.AddDbContext<DBContext>(options =>
-               options.UseInMemoryDatabase("GoodLuckDb"));
+               options.UseSqlServer(connectionString));
 
             var app = builder.Build();
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# GoodLuck
+
+## Hướng dẫn kết nối SQL Server
+
+1. Chỉnh sửa chuỗi kết nối tại `GoodLuck/appsettings.json` trong phân mục `ConnectionStrings`.
+2. Ứng dụng đọc chuỗi kết nối qua phương thức `UseSqlServer` tại file `Program.cs`.
+
+Ví dụ chuỗi kết nối:
+
+```json
+"ConnectionStrings": {
+    "DefaultConnection": "Server=(local);Database=Netflixx;User Id=sa;Password=sa123;TrustServerCertificate=true;"
+}
+```
+
+Trích đoạn mã khởi tạo DbContext:
+
+```csharp
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+builder.Services.AddDbContext<DBContext>(options =>
+    options.UseSqlServer(connectionString));
+```


### PR DESCRIPTION
## Summary
- use SQL Server connection string from appsettings
- add README with setup instructions

## Testing
- `dotnet test GoodLuck.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854d53b15ec8327bfdec69ae8527e55