### PR TITLE
Fix DBContext injection and add error view

### DIFF
--- a/GoodLuck/Controllers/AnniversariesController.cs
+++ b/GoodLuck/Controllers/AnniversariesController.cs
@@ -1,14 +1,15 @@
 using GoodLuck.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using GoodLuck.Repositories;
 
 namespace GoodLuck.Controllers
 {
     public class AnniversariesController : Controller
     {
-        private readonly DbContext _context;
+        private readonly DBContext _context;
 
-        public AnniversariesController(DbContext context)
+        public AnniversariesController(DBContext context)
         {
             _context = context;
         }

--- a/GoodLuck/Controllers/LettersController.cs
+++ b/GoodLuck/Controllers/LettersController.cs
@@ -1,14 +1,15 @@
 using GoodLuck.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using GoodLuck.Repositories;
 
 namespace GoodLuck.Controllers
 {
     public class LettersController : Controller
     {
-        private readonly DbContext _context;
+        private readonly DBContext _context;
 
-        public LettersController(DbContext context)
+        public LettersController(DBContext context)
         {
             _context = context;
         }

--- a/GoodLuck/Models/ErrorViewModel.cs
+++ b/GoodLuck/Models/ErrorViewModel.cs
@@ -1,0 +1,8 @@
+namespace GoodLuck.Models
+{
+    public class ErrorViewModel
+    {
+        public string? RequestId { get; set; }
+        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+    }
+}

--- a/GoodLuck/Views/Shared/Error.cshtml
+++ b/GoodLuck/Views/Shared/Error.cshtml
@@ -1,0 +1,14 @@
+@model GoodLuck.Models.ErrorViewModel
+@{
+    ViewData["Title"] = "Error";
+}
+
+<h1 class="text-danger">Error.</h1>
+<h2 class="text-danger">An error occurred while processing your request.</h2>
+
+@if (Model.ShowRequestId)
+{
+    <p>
+        <strong>Request ID:</strong> <code>@Model.RequestId</code>
+    </p>
+}


### PR DESCRIPTION
## Summary
- fix the injected type for `LettersController` and `AnniversariesController`
- add missing `ErrorViewModel` model and an `Error` view

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854d7de8b9c8327b0cca026075f88da