### PR TITLE
Add countdown on birthday page

### DIFF
--- a/GoodLuck/Controllers/HomeController.cs
+++ b/GoodLuck/Controllers/HomeController.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using GoodLuck.Models;
+using GoodLuck.Repositories;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GoodLuck.Controllers
@@ -7,14 +8,23 @@ namespace GoodLuck.Controllers
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;
+        private readonly DBContext _context;
 
-        public HomeController(ILogger<HomeController> logger)
+        public HomeController(ILogger<HomeController> logger, DBContext context)
         {
             _logger = logger;
+            _context = context;
         }
 
         public IActionResult Index()
         {
+            // Find the nearest upcoming anniversary (including today)
+            var upcoming = _context.Anniversaries
+                                   .Where(a => a.Date >= DateTime.Today)
+                                   .OrderBy(a => a.Date)
+                                   .FirstOrDefault();
+
+            ViewBag.NextAnniversary = upcoming;
             return View();
         }
 

--- a/GoodLuck/Views/Home/Index.cshtml
+++ b/GoodLuck/Views/Home/Index.cshtml
@@ -62,11 +62,18 @@
             <div class="page-content" id="birthday">
                 <h1 class="title">🎂 Chúc Mừng Sinh Nhật!</h1>
                 <p class="subtitle">Công chúa của anh...</p>
-                
+
                 <div class="cake-container">
                     <div class="cake">🎂</div>
                 </div>
-                
+
+                @if (ViewBag.NextAnniversary != null)
+                {
+                    <div class="countdown">
+                        Còn lại <span id="countdown"></span> nữa đến sự kiện "@ViewBag.NextAnniversary.Title"
+                    </div>
+                }
+
                 <div class="message">
                     Hôm nay là ngày đặc biệt nhất,<br>
                     Vì em đã đến với thế giới này.<br>
@@ -193,6 +200,38 @@ function togglePlay(btn) {
     } else {
         btn.textContent = '▶';
     }
+}
+
+function startCountdown(dateString) {
+    const target = new Date(dateString);
+    const span = document.getElementById('countdown');
+    if (!span) return;
+
+    function update() {
+        const now = new Date();
+        let diff = target - now;
+        if (diff < 0) diff = 0;
+
+        const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+        diff -= days * 1000 * 60 * 60 * 24;
+        const hours = Math.floor(diff / (1000 * 60 * 60));
+        diff -= hours * 1000 * 60 * 60;
+        const minutes = Math.floor(diff / (1000 * 60));
+        diff -= minutes * 1000 * 60;
+        const seconds = Math.floor(diff / 1000);
+
+        span.textContent = `${days}d ${hours}h ${minutes}m ${seconds}s`;
+    }
+
+    update();
+    setInterval(update, 1000);
+}
+
+@if (ViewBag.NextAnniversary != null)
+{
+    <text>
+        startCountdown('@(((DateTime)ViewBag.NextAnniversary.Date).ToString("o"))');
+    </text>
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- show nearest anniversary countdown on the birthday section
- fetch next anniversary in `HomeController`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ddf3137c8327879a91e56199436c