### PR TITLE
Link letters to anniversaries

### DIFF
--- a/GoodLuck/Controllers/HomeController.cs
+++ b/GoodLuck/Controllers/HomeController.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using GoodLuck.Models;
 using GoodLuck.Repositories;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace GoodLuck.Controllers
 {
@@ -23,6 +24,14 @@ namespace GoodLuck.Controllers
                                    .Where(a => a.Date >= DateTime.Today)
                                    .OrderBy(a => a.Date)
                                    .FirstOrDefault();
+
+            if (upcoming != null)
+            {
+                var letter = _context.Letters
+                                   .Include(l => l.Anniversary)
+                                   .FirstOrDefault(l => l.AnniversaryId == upcoming.Id);
+                ViewBag.NextLetter = letter;
+            }
 
             ViewBag.NextAnniversary = upcoming;
             return View();

--- a/GoodLuck/Controllers/LettersController.cs
+++ b/GoodLuck/Controllers/LettersController.cs
@@ -2,6 +2,7 @@ using GoodLuck.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using GoodLuck.Repositories;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace GoodLuck.Controllers
 {
@@ -16,12 +17,16 @@ namespace GoodLuck.Controllers
 
         public async Task<IActionResult> Index()
         {
-            var letters = await _context.Letters.OrderByDescending(l => l.Created).ToListAsync();
+            var letters = await _context.Letters
+                .Include(l => l.Anniversary)
+                .OrderByDescending(l => l.Created)
+                .ToListAsync();
             return View(letters);
         }
 
         public IActionResult Create()
         {
+            ViewBag.Anniversaries = new SelectList(_context.Anniversaries.OrderBy(a => a.Date), "Id", "Title");
             return View();
         }
 
@@ -36,6 +41,7 @@ namespace GoodLuck.Controllers
                 await _context.SaveChangesAsync();
                 return RedirectToAction(nameof(Index));
             }
+            ViewBag.Anniversaries = new SelectList(_context.Anniversaries.OrderBy(a => a.Date), "Id", "Title", letter.AnniversaryId);
             return View(letter);
         }
     }

--- a/GoodLuck/Models/Letter.cs
+++ b/GoodLuck/Models/Letter.cs
@@ -15,5 +15,11 @@ namespace GoodLuck.Models
         [Required]
 
         public DateTime Created { get; set; }
+
+        // Link to an anniversary so the letter can be displayed
+        // when the event occurs
+        [Required]
+        public int AnniversaryId { get; set; }
+        public Anniversary? Anniversary { get; set; }
     }
 }

--- a/GoodLuck/Views/Home/Index.cshtml
+++ b/GoodLuck/Views/Home/Index.cshtml
@@ -72,6 +72,15 @@
                     <div class="countdown">
                         Còn lại <span id="countdown"></span> nữa đến sự kiện "@ViewBag.NextAnniversary.Title"
                     </div>
+                    @if (ViewBag.NextLetter != null)
+                    {
+                        <div class="special-message" id="eventLetter">
+                            <button class="close-btn" onclick="hideEventLetter()">×</button>
+                            <div class="message-text">
+                                @Html.Raw(((GoodLuck.Models.Letter)ViewBag.NextLetter).Content.Replace("\n", "<br>"))
+                            </div>
+                        </div>
+                    }
                 }
 
                 <div class="message">
@@ -179,6 +188,15 @@ function hideLoveMessage() {
     document.getElementById('loveMessage').style.display = 'none';
 }
 
+function showEventLetter() {
+    const el = document.getElementById('eventLetter');
+    if (el) el.style.display = 'block';
+}
+function hideEventLetter() {
+    const el = document.getElementById('eventLetter');
+    if (el) el.style.display = 'none';
+}
+
 function createFireworks() {
     // placeholder for fireworks effect
 }
@@ -205,12 +223,16 @@ function togglePlay(btn) {
 function startCountdown(dateString) {
     const target = new Date(dateString);
     const span = document.getElementById('countdown');
+    const letterDiv = document.getElementById('eventLetter');
     if (!span) return;
 
     function update() {
         const now = new Date();
         let diff = target - now;
-        if (diff < 0) diff = 0;
+        if (diff <= 0) {
+            diff = 0;
+            if (letterDiv) letterDiv.style.display = 'block';
+        }
 
         const days = Math.floor(diff / (1000 * 60 * 60 * 24));
         diff -= days * 1000 * 60 * 60 * 24;

--- a/GoodLuck/Views/Letters/Create.cshtml
+++ b/GoodLuck/Views/Letters/Create.cshtml
@@ -11,5 +11,9 @@
         <label asp-for="Content" class="form-label"></label>
         <textarea asp-for="Content" class="form-control"></textarea>
     </div>
+    <div class="mb-3">
+        <label asp-for="AnniversaryId" class="form-label">Anniversary</label>
+        <select asp-for="AnniversaryId" class="form-control" asp-items="ViewBag.Anniversaries"></select>
+    </div>
     <button type="submit" class="btn btn-primary">Save</button>
 </form>

--- a/GoodLuck/Views/Letters/Index.cshtml
+++ b/GoodLuck/Views/Letters/Index.cshtml
@@ -9,7 +9,7 @@
         <tr>
             <th>Title</th>
             <th>Date</th>
-            <th></th>
+            <th>Anniversary</th>
         </tr>
     </thead>
     <tbody>
@@ -18,6 +18,7 @@
         <tr>
             <td>@item.Title</td>
             <td>@item.Created.ToString("yyyy-MM-dd")</td>
+            <td>@item.Anniversary?.Title</td>
         </tr>
 }
     </tbody>


### PR DESCRIPTION
## Summary
- associate `Letter` with `Anniversary`
- allow selecting anniversary when creating letters
- display anniversary column on the letter listing
- show the letter for the next event on the homepage when countdown ends

## Testing
- `dotnet build GoodLuck.sln`

------
https://chatgpt.com/codex/tasks/task_e_6854e032810883279a32cc7b6f80f0b6