### PR TITLE
Fix letter creation without existing anniversary

### DIFF
--- a/GoodLuck/Controllers/LettersController.cs
+++ b/GoodLuck/Controllers/LettersController.cs
@@ -34,6 +34,12 @@ namespace GoodLuck.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create(Letter letter)
         {
+            // Ensure the selected anniversary exists before saving
+            if (!_context.Anniversaries.Any(a => a.Id == letter.AnniversaryId))
+            {
+                ModelState.AddModelError("AnniversaryId", "Anniversary does not exist.");
+            }
+
             if (ModelState.IsValid)
             {
                 letter.Created = DateTime.UtcNow;


### PR DESCRIPTION
## Summary
- verify the chosen anniversary exists before saving a new letter

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e2a310308327a72cf4682f592d97