### PR TITLE
Add time fields to anniversary events

### DIFF
--- a/GoodLuck/Views/Anniversaries/Create.cshtml
+++ b/GoodLuck/Views/Anniversaries/Create.cshtml
@@ -9,7 +9,7 @@
     </div>
     <div class="mb-3">
         <label asp-for="Date" class="form-label"></label>
-        <input asp-for="Date" type="date" class="form-control" />
+        <input asp-for="Date" type="datetime-local" class="form-control" />
     </div>
     <button type="submit" class="btn btn-primary">Save</button>
 </form>

--- a/GoodLuck/Views/Anniversaries/Index.cshtml
+++ b/GoodLuck/Views/Anniversaries/Index.cshtml
@@ -16,7 +16,7 @@
 {
         <tr>
             <td>@item.Title</td>
-            <td>@item.Date.ToString("yyyy-MM-dd")</td>
+            <td>@item.Date.ToString("yyyy-MM-dd HH:mm")</td>
         </tr>
 }
     </tbody>


### PR DESCRIPTION
## Summary
- allow picking date and time when creating anniversaries
- show full date and time in anniversary list

## Testing
- `dotnet build GoodLuck/GoodLuck.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6854e2df614083278a71e85d444db5ca