### PR TITLE
Enable calendar month navigation

### DIFF
--- a/GoodLuck/Controllers/HomeController.cs
+++ b/GoodLuck/Controllers/HomeController.cs
@@ -42,11 +42,32 @@ namespace GoodLuck.Controllers
             return View();
         }
 
-        public IActionResult Calendar()
+        public IActionResult Calendar(int? month, int? year)
         {
+            DateTime displayDate;
+            if (month.HasValue && year.HasValue)
+            {
+                displayDate = new DateTime(year.Value, month.Value, 1);
+            }
+            else if (month.HasValue)
+            {
+                displayDate = new DateTime(DateTime.Today.Year, month.Value, 1);
+            }
+            else if (year.HasValue)
+            {
+                displayDate = new DateTime(year.Value, DateTime.Today.Month, 1);
+            }
+            else
+            {
+                displayDate = new DateTime(DateTime.Today.Year, DateTime.Today.Month, 1);
+            }
+
             var events = _context.Anniversaries
+                                  .Where(a => a.Date.Year == displayDate.Year && a.Date.Month == displayDate.Month)
                                   .OrderBy(a => a.Date)
                                   .ToList();
+
+            ViewBag.DisplayDate = displayDate;
             return View(events);
         }
 

--- a/GoodLuck/Views/Home/Calendar.cshtml
+++ b/GoodLuck/Views/Home/Calendar.cshtml
@@ -1,17 +1,23 @@
 @model IEnumerable<GoodLuck.Models.Anniversary>
 
 @{
-    var now = DateTime.Today;
+    var now = (DateTime)ViewBag.DisplayDate;
     var firstOfMonth = new DateTime(now.Year, now.Month, 1);
     var daysInMonth = DateTime.DaysInMonth(now.Year, now.Month);
     var startOffset = (int)firstOfMonth.DayOfWeek;
     var eventsByDay = Model
         .GroupBy(a => a.Date.Date)
         .ToDictionary(g => g.Key, g => g.ToList());
+    var prev = now.AddMonths(-1);
+    var next = now.AddMonths(1);
 }
 
 <div class="calendar-book">
-    <h2 class="text-center">@now.ToString("MMMM yyyy")</h2>
+    <div class="calendar-nav text-center mb-3">
+        <a asp-action="Calendar" asp-route-month="@prev.Month" asp-route-year="@prev.Year" class="btn btn-sm btn-secondary">&laquo;</a>
+        <span class="mx-2 fw-bold">@now.ToString("MMMM yyyy")</span>
+        <a asp-action="Calendar" asp-route-month="@next.Month" asp-route-year="@next.Year" class="btn btn-sm btn-secondary">&raquo;</a>
+    </div>
     <div class="calendar">
         <div class="day-header">CN</div>
         <div class="day-header">T2</div>

--- a/GoodLuck/wwwroot/css/site.css
+++ b/GoodLuck/wwwroot/css/site.css
@@ -65,6 +65,15 @@ body {
 }
 
 .event-title {
-  font-size: 0.8rem;
-  line-height: 1.1rem;
+    font-size: 0.8rem;
+    line-height: 1.1rem;
+ }
+
+.calendar-nav a {
+    text-decoration: none;
+    padding: 0 10px;
+}
+
+.calendar-nav span {
+    font-size: 1.25rem;
 }


### PR DESCRIPTION
## Summary
- add month/year parameters in `Calendar` action
- show month navigation controls in Calendar view
- style new month navigation controls

## Testing
- `dotnet build GoodLuck.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68550cfc5ab8832798c480608c259e42