### PR TITLE
Add love frame on home page

### DIFF
--- a/GoodLuck/Controllers/HomeController.cs
+++ b/GoodLuck/Controllers/HomeController.cs
@@ -65,6 +65,15 @@ namespace GoodLuck.Controllers
 
             ViewBag.NextAnniversary = upcoming;
             ViewBag.Photos = LoadPhotos().TakeLast(2).ToList();
+
+            var first = _context.Anniversaries.OrderBy(a => a.Date).FirstOrDefault();
+            int daysTogether = 0;
+            if (first != null)
+            {
+                daysTogether = (int)(DateTime.Today - first.Date.Date).TotalDays;
+                if (daysTogether < 0) daysTogether = 0;
+            }
+            ViewBag.DaysTogether = daysTogether;
             return View();
         }
 

--- a/GoodLuck/Views/Home/Index.cshtml
+++ b/GoodLuck/Views/Home/Index.cshtml
@@ -36,6 +36,11 @@
             <div class="page-content active" id="home">
                 <h1 class="title">💕 Cặp Đôi Đặc Biệt</h1>
 
+                <div class="love-frame">
+                    <span class="days-count">@ViewBag.DaysTogether</span>
+                    <span class="heart-icon pulse-heart">❤️</span>
+                </div>
+
                 <div class="home-photos">
                     <div class="photos-grid">
                         @if (ViewBag.Photos != null)
@@ -43,7 +48,9 @@
                             foreach (GoodLuck.Models.Photo p in ViewBag.Photos)
                             {
                                 <div class="photo-item" style="text-align:center;margin:10px;">
-                                    <img src="~/uploads/@p.FileName" alt="@p.Title" style="max-width:100%;height:auto;" />
+                                    <div class="photo-frame">
+                                        <img src="~/uploads/@p.FileName" alt="@p.Title" style="max-width:100%;height:auto;" />
+                                    </div>
                                     <div style="color:white;">@p.Title</div>
                                 </div>
                             }

--- a/GoodLuck/wwwroot/css/home.css
+++ b/GoodLuck/wwwroot/css/home.css
@@ -634,3 +634,32 @@ body {
     cursor: pointer;
     border-radius: 5px;
 }
+
+/* Love frame on home page */
+.love-frame {
+    position: relative;
+    width: 220px;
+    height: 220px;
+    margin: 0 auto 20px;
+    border: 8px solid rgba(255, 255, 255, 0.4);
+    border-radius: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    backdrop-filter: blur(10px);
+}
+
+.love-frame .heart-icon {
+    font-size: 4rem;
+}
+
+.love-frame .days-count {
+    position: absolute;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    color: white;
+    font-size: 2rem;
+    font-weight: bold;
+    text-shadow: 0 2px 5px rgba(0, 0, 0, 0.6);
+}


### PR DESCRIPTION
## Summary
- compute days since earliest anniversary
- add a love frame with heart and days counter on the home page
- wrap home photos in photo frames for consistent look
- style new love frame in `home.css`

## Testing
- `dotnet build GoodLuck.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555d1cc8b8832784371047b4bfa00c