### PR TITLE
Enable start date editing

### DIFF
--- a/GoodLuck/Controllers/HomeController.cs
+++ b/GoodLuck/Controllers/HomeController.cs
@@ -80,7 +80,27 @@ namespace GoodLuck.Controllers
         public IActionResult Edit()
         {
             ViewBag.Photos = LoadPhotos();
+            var first = _context.Anniversaries.OrderBy(a => a.Date).FirstOrDefault();
+            ViewBag.StartDate = first?.Date.ToString("yyyy-MM-dd") ?? DateTime.Today.ToString("yyyy-MM-dd");
             return View();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> SetStartDate(DateTime startDate)
+        {
+            var first = await _context.Anniversaries.OrderBy(a => a.Date).FirstOrDefaultAsync();
+            if (first != null)
+            {
+                first.Date = startDate.Date;
+                _context.Update(first);
+            }
+            else
+            {
+                _context.Anniversaries.Add(new Anniversary { Title = "Ngày Bắt Đầu", Date = startDate.Date });
+            }
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Edit));
         }
 
         [HttpPost]

--- a/GoodLuck/Views/Home/Edit.cshtml
+++ b/GoodLuck/Views/Home/Edit.cshtml
@@ -31,3 +31,11 @@
     </div>
     <button type="submit" class="btn btn-primary">Tải lên</button>
 </form>
+
+<form asp-action="SetStartDate" method="post" class="mt-4">
+    <div class="mb-3">
+        <label for="startDate" class="form-label">Ngày bắt đầu</label>
+        <input type="date" name="startDate" id="startDate" class="form-control" value="@ViewBag.StartDate" />
+    </div>
+    <button type="submit" class="btn btn-primary">Lưu ngày bắt đầu</button>
+</form>


### PR DESCRIPTION
## Summary
- set `ViewBag.StartDate` with the earliest anniversary date
- add a `SetStartDate` action to HomeController
- allow choosing the start date on the home edit page

## Testing
- `dotnet build --nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555f12d2808327a1514c830914c136