### PR TITLE
Allow customizing icon for anniversaries

### DIFF
--- a/GoodLuck/Models/Anniversary.cs
+++ b/GoodLuck/Models/Anniversary.cs
@@ -15,5 +15,9 @@ namespace GoodLuck.Models
 
         // Optional message to display when the event starts
         public string? Message { get; set; }
+
+        // Icon to display for the event (emoji or character)
+        [Required]
+        public string Icon { get; set; } = "\uD83D\uDC95"; // default to 💕
     }
 }

--- a/GoodLuck/Views/Anniversaries/Create.cshtml
+++ b/GoodLuck/Views/Anniversaries/Create.cshtml
@@ -12,6 +12,10 @@
         <input asp-for="Date" type="datetime-local" class="form-control" />
     </div>
     <div class="mb-3">
+        <label asp-for="Icon" class="form-label">Icon</label>
+        <input asp-for="Icon" class="form-control" />
+    </div>
+    <div class="mb-3">
         <label asp-for="Message" class="form-label"></label>
         <textarea asp-for="Message" class="form-control"></textarea>
     </div>

--- a/GoodLuck/Views/Anniversaries/Edit.cshtml
+++ b/GoodLuck/Views/Anniversaries/Edit.cshtml
@@ -13,6 +13,10 @@
         <input asp-for="Date" type="datetime-local" class="form-control" />
     </div>
     <div class="mb-3">
+        <label asp-for="Icon" class="form-label">Icon</label>
+        <input asp-for="Icon" class="form-control" />
+    </div>
+    <div class="mb-3">
         <label asp-for="Message" class="form-label"></label>
         <textarea asp-for="Message" class="form-control"></textarea>
     </div>

--- a/GoodLuck/Views/Anniversaries/Index.cshtml
+++ b/GoodLuck/Views/Anniversaries/Index.cshtml
@@ -9,6 +9,7 @@
         <tr>
             <th>Title</th>
             <th>Date</th>
+            <th>Icon</th>
             <th>Message</th>
             <th></th>
         </tr>
@@ -19,6 +20,7 @@
         <tr>
             <td>@item.Title</td>
             <td>@item.Date.ToString("yyyy-MM-dd HH:mm")</td>
+            <td>@item.Icon</td>
             <td>@item.Message</td>
             <td>
                 <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-secondary">Edit</a>

--- a/GoodLuck/Views/Home/Calendar.cshtml
+++ b/GoodLuck/Views/Home/Calendar.cshtml
@@ -55,12 +55,13 @@
     var classes = "day";
     if (date.Month != displayDate.Month) classes += " other-month";
     if (ann != null) classes += " event";
+    var icon = ann?.Icon ?? "\uD83D\uDC95";
 
-<div class="@classes">
+<div class="@classes" data-icon="@icon">
     <div class="date-num">@date.Day</div>
     @if (ann != null)
     {
-        <div class="event-title">@ann.Title</div>
+        <div class="event-title">@ann.Icon @ann.Title</div>
     }
 </div>
 }

--- a/GoodLuck/Views/Home/Index.cshtml
+++ b/GoodLuck/Views/Home/Index.cshtml
@@ -67,11 +67,11 @@
             <!-- Birthday Page -->
             <div class="page-content" id="birthday">
                 <div id="birthdayMessage" style="display: none;">
-                    <h1 class="title">🎉 @ViewBag.NextAnniversary?.Title</h1>
+                    <h1 class="title">@(ViewBag.NextAnniversary?.Icon ?? "🎉") @ViewBag.NextAnniversary?.Title</h1>
                     <p class="subtitle">@ViewBag.NextAnniversary?.Message</p>
 
                     <div class="cake-container">
-                        <div class="cake">🎂</div>
+                        <div class="cake">@(ViewBag.NextAnniversary?.Icon ?? "🎂")</div>
                     </div>
                 </div>
 

--- a/GoodLuck/wwwroot/css/Calender.css
+++ b/GoodLuck/wwwroot/css/Calender.css
@@ -316,7 +316,7 @@ body {
 }
 
 .day.event::before {
-    content: '💕';
+    content: attr(data-icon);
     position: absolute;
     top: 5px;
     right: 5px;


### PR DESCRIPTION
## Summary
- add `Icon` property to `Anniversary` model
- display and edit event icon in Anniversary views
- show upcoming anniversary icon on home page
- support per-event icons on calendar days
- use event icon attribute in calendar CSS

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555f83df9483278f73082a08a16e31