### PR TITLE
Fix home heart layout

### DIFF
--- a/GoodLuck/Views/Home/Index.cshtml
+++ b/GoodLuck/Views/Home/Index.cshtml
@@ -37,8 +37,18 @@
                 <h1 class="title">💕 Cặp Đôi Đặc Biệt</h1>
 
                 <div class="love-frame">
+                    @if (ViewBag.Photos != null && ((List<GoodLuck.Models.Photo>)ViewBag.Photos).Count >= 2)
+                    {
+                        var photos = (List<GoodLuck.Models.Photo>)ViewBag.Photos;
+                        <img class="love-photo" src="~/uploads/@photos[0].FileName" alt="@photos[0].Title" />
+                        <span class="heart-icon pulse-heart">❤️</span>
+                        <img class="love-photo" src="~/uploads/@photos[1].FileName" alt="@photos[1].Title" />
+                    }
+                    else
+                    {
+                        <span class="heart-icon pulse-heart">❤️</span>
+                    }
                     <span class="days-count">@ViewBag.DaysTogether</span>
-                    <span class="heart-icon pulse-heart">❤️</span>
                 </div>
 
                 <div class="home-photos">

--- a/GoodLuck/wwwroot/css/home.css
+++ b/GoodLuck/wwwroot/css/home.css
@@ -638,15 +638,17 @@ body {
 /* Love frame on home page */
 .love-frame {
     position: relative;
-    width: 220px;
-    height: 220px;
     margin: 0 auto 20px;
-    border: 8px solid rgba(255, 255, 255, 0.4);
-    border-radius: 20px;
     display: flex;
     align-items: center;
     justify-content: center;
-    backdrop-filter: blur(10px);
+    gap: 20px;
+}
+
+.love-photo {
+    width: 120px;
+    height: auto;
+    border-radius: 10px;
 }
 
 .love-frame .heart-icon {


### PR DESCRIPTION
## Summary
- center the heart between the newest photos on the home page
- display uploaded photos left and right of the heart
- tweak styles for the love frame

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855601aa7788327862e9b99aa93d08e