### PR TITLE
Fix photo display on homepage

### DIFF
--- a/GoodLuck/Controllers/HomeController.cs
+++ b/GoodLuck/Controllers/HomeController.cs
@@ -64,7 +64,9 @@ namespace GoodLuck.Controllers
             }
 
             ViewBag.NextAnniversary = upcoming;
-            ViewBag.Photos = LoadPhotos().TakeLast(2).ToList();
+            var allPhotos = LoadPhotos();
+            ViewBag.MainPhotos = allPhotos.TakeLast(2).ToList();
+            ViewBag.Photos = allPhotos;
 
             var first = await _context.Anniversaries.OrderBy(a => a.Date).FirstOrDefaultAsync();
             int daysTogether = 0;

--- a/GoodLuck/Views/Home/Index.cshtml
+++ b/GoodLuck/Views/Home/Index.cshtml
@@ -37,9 +37,9 @@
                 <h1 class="title">💕 Cặp Đôi Đặc Biệt</h1>
 
                 <div class="love-frame">
-                    @if (ViewBag.Photos != null && ((List<GoodLuck.Models.Photo>)ViewBag.Photos).Count >= 2)
+                    @if (ViewBag.MainPhotos != null && ((List<GoodLuck.Models.Photo>)ViewBag.MainPhotos).Count >= 2)
                     {
-                        var photos = (List<GoodLuck.Models.Photo>)ViewBag.Photos;
+                        var photos = (List<GoodLuck.Models.Photo>)ViewBag.MainPhotos;
                         <div class="photo-frame">
                             <img class="love-photo" src="~/uploads/@photos[0].FileName" alt="@photos[0].Title" />
                         </div>


### PR DESCRIPTION
## Summary
- load all photos and keep the last two separately
- update home page to use `MainPhotos` for the featured pair

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build GoodLuck/GoodLuck.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68556376f7e48327a57761ffa0d14b8b