### PR TITLE
Fix image frames on homepage

### DIFF
--- a/GoodLuck/wwwroot/css/home.css
+++ b/GoodLuck/wwwroot/css/home.css
@@ -645,9 +645,19 @@ body {
     gap: 20px;
 }
 
+.love-frame .photo-frame {
+    width: 150px;
+    height: 150px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
 .love-photo {
-    width: 120px;
-    height: auto;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
     border-radius: 10px;
 }
 


### PR DESCRIPTION
## Summary
- style homepage image frames with equal width/height
- ensure uploaded images fill their frames

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685564d0a3388327a4bd09d63968ee81