### PR TITLE
Synchronize Anniversary model updates

### DIFF
--- a/GoodLuck/Controllers/AnniversariesController.cs
+++ b/GoodLuck/Controllers/AnniversariesController.cs
@@ -46,10 +46,6 @@ namespace GoodLuck.Controllers
 
             if (ModelState.IsValid)
             {
-                if (!string.IsNullOrWhiteSpace(anniversary.LetterTitle) && !string.IsNullOrWhiteSpace(anniversary.LetterContent) && !anniversary.LetterCreated.HasValue)
-                {
-                    anniversary.LetterCreated = DateTime.UtcNow;
-                }
                 _context.Update(anniversary);
                 await _context.SaveChangesAsync();
                 return RedirectToAction(nameof(Index));
@@ -102,10 +98,6 @@ namespace GoodLuck.Controllers
         {
             if (ModelState.IsValid)
             {
-                if (!string.IsNullOrWhiteSpace(anniversary.LetterTitle) && !string.IsNullOrWhiteSpace(anniversary.LetterContent))
-                {
-                    anniversary.LetterCreated = DateTime.UtcNow;
-                }
                 _context.Add(anniversary);
                 await _context.SaveChangesAsync();
 

--- a/GoodLuck/Views/Anniversaries/Create.cshtml
+++ b/GoodLuck/Views/Anniversaries/Create.cshtml
@@ -20,15 +20,11 @@
         <span asp-validation-for="Icon" class="text-danger"></span>
     </div>
     <div class="mb-3">
-        <label asp-for="Message" class="form-label"></label>
-        <textarea asp-for="Message" class="form-control"></textarea>
-        <span asp-validation-for="Message" class="text-danger"></span>
+        <label asp-for="SubTitle" class="form-label"></label>
+        <textarea asp-for="SubTitle" class="form-control"></textarea>
+        <span asp-validation-for="SubTitle" class="text-danger"></span>
     </div>
     <h2>Letter</h2>
-    <div class="mb-3">
-        <label asp-for="LetterTitle" class="form-label"></label>
-        <input asp-for="LetterTitle" class="form-control" />
-    </div>
     <div class="mb-3">
         <label asp-for="LetterContent" class="form-label"></label>
         <textarea asp-for="LetterContent" class="form-control"></textarea>

--- a/GoodLuck/Views/Anniversaries/Delete.cshtml
+++ b/GoodLuck/Views/Anniversaries/Delete.cshtml
@@ -5,7 +5,7 @@
 <div>
     <h4>@Model.Title</h4>
     <p>@Model.Date.ToString("yyyy-MM-dd HH:mm")</p>
-    <p>@Model.Message</p>
+    <p>@Model.SubTitle</p>
 </div>
 
 <form asp-action="Delete" method="post">

--- a/GoodLuck/Views/Anniversaries/Edit.cshtml
+++ b/GoodLuck/Views/Anniversaries/Edit.cshtml
@@ -17,14 +17,10 @@
         <input asp-for="Icon" class="form-control" />
     </div>
     <div class="mb-3">
-        <label asp-for="Message" class="form-label"></label>
-        <textarea asp-for="Message" class="form-control"></textarea>
+        <label asp-for="SubTitle" class="form-label"></label>
+        <textarea asp-for="SubTitle" class="form-control"></textarea>
     </div>
     <h2>Letter</h2>
-    <div class="mb-3">
-        <label asp-for="LetterTitle" class="form-label"></label>
-        <input asp-for="LetterTitle" class="form-control" />
-    </div>
     <div class="mb-3">
         <label asp-for="LetterContent" class="form-label"></label>
         <textarea asp-for="LetterContent" class="form-control"></textarea>

--- a/GoodLuck/Views/Anniversaries/Index.cshtml
+++ b/GoodLuck/Views/Anniversaries/Index.cshtml
@@ -10,7 +10,7 @@
             <th>Title</th>
             <th>Date</th>
             <th>Icon</th>
-            <th>Message</th>
+            <th>SubTitle</th>
             <th></th>
         </tr>
     </thead>
@@ -21,7 +21,7 @@
             <td>@item.Title</td>
             <td>@item.Date.ToString("yyyy-MM-dd HH:mm")</td>
             <td>@item.Icon</td>
-            <td>@item.Message</td>
+            <td>@item.SubTitle</td>
             <td>
                 <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-secondary">Edit</a>
                 <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-sm btn-danger">Delete</a>

--- a/GoodLuck/Views/Home/Index.cshtml
+++ b/GoodLuck/Views/Home/Index.cshtml
@@ -72,7 +72,7 @@
             <div class="page-content" id="birthday">
                 <div id="birthdayMessage" style="display: none;">
                     <h1 class="title">@(ViewBag.NextAnniversary?.Icon ?? "🎉") @ViewBag.NextAnniversary?.Title</h1>
-                    <p class="subtitle">@ViewBag.NextAnniversary?.Message</p>
+                    <p class="subtitle">@ViewBag.NextAnniversary?.SubTitle</p>
 
                     <div class="cake-container">
                         <div class="cake">@(ViewBag.NextAnniversary?.Icon ?? "🎂")</div>


### PR DESCRIPTION
## Summary
- remove Letter* logic from `AnniversariesController`
- update Anniversary forms to use `SubTitle`
- drop `Message` column in table views
- show subtitle on home page

## Testing
- `dotnet build GoodLuck.sln`
- `dotnet test GoodLuck.sln`

------
https://chatgpt.com/codex/tasks/task_e_68556fcc74e48327999405c05eb8df8b