### PR TITLE
Store photos in database

### DIFF
--- a/GoodLuck/Models/Photo.cs
+++ b/GoodLuck/Models/Photo.cs
@@ -1,9 +1,12 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace GoodLuck.Models
 {
     public class Photo
     {
+        [Key]
+        public int Id { get; set; }
         public string FileName { get; set; } = string.Empty;
         public string Title { get; set; } = string.Empty;
         public DateTime Uploaded { get; set; }

--- a/GoodLuck/Repositories/DBContext.cs
+++ b/GoodLuck/Repositories/DBContext.cs
@@ -10,5 +10,6 @@ namespace GoodLuck.Repositories
         }
 
         public DbSet<Anniversary> Anniversaries => Set<Anniversary>();
+        public DbSet<Photo> Photos => Set<Photo>();
     }
 }


### PR DESCRIPTION
## Summary
- add ID and data annotations to `Photo` model
- add `DbSet<Photo>` to the EF database context
- update `HomeController` to save and load photos from the database
- allow adding a home photo via new endpoint

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855735819308327adf37926a3fe29eb